### PR TITLE
Disable ecto

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,13 +1,13 @@
 use Mix.Config
 
 # Configure your database
-config :twinkly_maha, TwinklyMaha.Repo,
-  username: "postgres",
-  password: "postgres",
-  database: "twinklymaha_dev",
-  hostname: "localhost",
-  show_sensitive_data_on_connection_error: true,
-  pool_size: 10
+# config :twinkly_maha, TwinklyMaha.Repo,
+#   username: "postgres",
+#   password: "postgres",
+#   database: "twinklymaha_dev",
+#   hostname: "localhost",
+#   show_sensitive_data_on_connection_error: true,
+#   pool_size: 10
 
 # For development, we disable any cache and enable
 # debugging and code reloading.

--- a/lib/twinkly_maha/application.ex
+++ b/lib/twinkly_maha/application.ex
@@ -8,7 +8,7 @@ defmodule TwinklyMaha.Application do
   def start(_type, _args) do
     children = [
       # Start the Ecto repository
-      TwinklyMaha.Repo,
+      # TwinklyMaha.Repo,
       # Start the Telemetry supervisor
       TwinklyMahaWeb.Telemetry,
       # Start the PubSub system


### PR DESCRIPTION
At the moment there are no records been saved into the database. Hence disabling migration of the database to prevent throwing of errors when launching an instance to GCP