### PR TITLE
enable turn on LED using command scripts

### DIFF
--- a/lib/Oc2/do_set.ex
+++ b/lib/Oc2/do_set.ex
@@ -45,6 +45,11 @@ defmodule Oc2.DoSet do
     %Oc2.Command{command | response: %{status: 200}}
   end
 
+  defp set_color("on", command) do
+    Phoenix.PubSub.broadcast(TwinklyMaha.PubSub, @topic, "on")
+    %Oc2.Command{command | response: %{status: 200}}
+  end
+
   defp set_color(color, command) do
     if color in @colors do
       Phoenix.PubSub.broadcast(TwinklyMaha.PubSub, @topic, color)

--- a/lib/twinkly_maha_web/live/twinkly_live.ex
+++ b/lib/twinkly_maha_web/live/twinkly_live.ex
@@ -94,7 +94,7 @@ defmodule TwinklyMahaWeb.TwinklyLive do
 
   def handle_info("off", socket) do
     Logger.debug("tlive:hand.info- off")
-    {:noreply, assign(socket, :current_color, "rgba(0, 0, 0, 0.2)")}
+    {:noreply, current_color(socket, "rgba(0, 0, 0, 0.2)", false)}
   end
 
   def handle_info(color, socket)
@@ -125,12 +125,12 @@ defmodule TwinklyMahaWeb.TwinklyLive do
     assign(socket, :current_color, "rainbow")
   end
 
-  defp current_color(socket, _color, false = _led_on?) do
-    assign(socket, :current_color, "rgba(0, 0, 0, 0.2)")
+  defp current_color(socket, color, false = led_on?) do
+    assign(socket, current_color: color, led_on?: led_on?)
   end
 
-  defp current_color(socket, color, true = _led_on?) do
-    assign(socket, :current_color, color)
+  defp current_color(socket, color, true = led_on?) do
+    assign(socket, current_color: color, led_on?: led_on?)
   end
 
   defp toggle_led(socket) do

--- a/test/Oc2/do_set_test.exs
+++ b/test/Oc2/do_set_test.exs
@@ -78,4 +78,19 @@ defmodule DoSetTest do
     assert command.error? == false
     assert command.response.status == 200
   end
+
+  test "led on" do
+    command =
+      %Oc2.Command{
+        error?: false,
+        action: "set",
+        target: "x-sfractal-blinky:led",
+        target_specifier: "on"
+      }
+      |> Oc2.DoSet.do_cmd()
+
+    assert command.error_msg == nil
+    assert command.error? == false
+    assert command.response.status == 200
+  end
 end


### PR DESCRIPTION
Initially you were only able to turn on LED from the UI using the "Turn LED on" button. This issue works on enabling user to turn on the LED using commands scripts.