### PR TITLE
Blinky led target action

### DIFF
--- a/lib/Oc2/check_oc2.ex
+++ b/lib/Oc2/check_oc2.ex
@@ -7,8 +7,8 @@ defmodule Oc2.CheckOc2 do
   """
 
   @actions ["query", "set", "cancel", "allow", "deny"]
-  @targets ["sbom", "features", "x-sfractal-blinky:hello_world",
-            "x-sfractal-blinky:led", "ipv4_net", "ipv6_net"]
+  @targets ["sbom", "features", "blinky:hello_world",
+            "blinky:led", "ipv4_net", "ipv6_net"]
   @top_level ["action", "target", "args", "actuator", "command_id"]
   @response ["none", "complete"]
   @action_target_pairs [
@@ -16,6 +16,7 @@ defmodule Oc2.CheckOc2 do
       {"query", "sbom"},
       {"query", "blinky:hello_world"},
       {"set", "blinky:led"},
+      {"set", "x-sfractal-blinky:led"},
       {"allow", "ipv4_net"},
       {"allow", "ipv6_net"},
       {"deny", "ipv4_net"},

--- a/lib/Oc2/do_query_features.ex
+++ b/lib/Oc2/do_query_features.ex
@@ -13,6 +13,7 @@ defmodule Oc2.DoQueryFeatures do
       :"x-sfractal-blinky:hello_world"
     ],
     set: [
+      :"blinky:led",
       :"x-sfractal-blinky:led",
       :"x-sfractal-blinky:buzzer",
       :"x-sfractal-blinky:valve",

--- a/lib/Oc2/do_set.ex
+++ b/lib/Oc2/do_set.ex
@@ -25,7 +25,7 @@ defmodule Oc2.DoSet do
     Oc2.Command.return_error("wrong action in command")
   end
 
-  def do_cmd(%Oc2.Command{target_specifier: color, target: "x-sfractal-blinky:led"} = command) do
+  def do_cmd(%Oc2.Command{target_specifier: color, target: "blinky:led"} = command) do
     set_color(color, command)
   end
 

--- a/lib/mqtt.ex
+++ b/lib/mqtt.ex
@@ -54,7 +54,6 @@ defmodule Mqtt do
 
     server = {Tortoise.Transport.Tcp, host: mqtt_host, port: mqtt_port}
 
-    # user_name = "Cav01"
     user_name =
       System.get_env("USER_NAME") ||
         raise """
@@ -65,7 +64,6 @@ defmodule Mqtt do
 
     Logger.info("user_name is #{user_name}")
 
-    # password = "Tango01Village"
     password =
       System.get_env("PASSWORD") ||
         raise """

--- a/lib/mqtt.ex
+++ b/lib/mqtt.ex
@@ -12,6 +12,7 @@ defmodule Mqtt do
   and starts supervisor of mqtt client
   """
   def start do
+    # client_id = "sfractal2023"
     client_id =
       System.get_env("CLIENT_ID") ||
         raise """
@@ -21,6 +22,9 @@ defmodule Mqtt do
         """
 
     Logger.info("client_id is #{client_id}")
+
+    # mqtt_host = "3271a3ddd2eb43caa7c4b195c7d6cabd.s2.eu.hivemq.cloud"
+    # mqtt_host = "test.mosquitto.org"
 
     mqtt_host =
       System.get_env("MQTT_HOST") ||
@@ -32,6 +36,9 @@ defmodule Mqtt do
         """
 
     Logger.info("mqtt_host is #{mqtt_host}")
+
+    # mqtt_port = 8883
+    # mqtt_port = 1883
 
     mqtt_port =
       String.to_integer(
@@ -47,6 +54,7 @@ defmodule Mqtt do
 
     server = {Tortoise.Transport.Tcp, host: mqtt_host, port: mqtt_port}
 
+    # user_name = "Cav01"
     user_name =
       System.get_env("USER_NAME") ||
         raise """
@@ -57,6 +65,7 @@ defmodule Mqtt do
 
     Logger.info("user_name is #{user_name}")
 
+    # password = "Tango01Village"
     password =
       System.get_env("PASSWORD") ||
         raise """

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule TwinklyMaha.MixProject do
     [
       app: :twinkly_maha,
       version: "0.9.1",
-      elixir: "~> 1.14.5",
+      elixir: "~> 1.12.2",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix] ++ Mix.compilers(),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
File check_oc2.ex. 
There was a mismatch between the targets and the action targets.  One had "blinky:led" and the other had "x-sfractal-blinky:led".  Update applied to include "blinky:led" which sounds like the latest version per Duncan.

File mix.exs.
There was an error when attempting to setup the app.  Reduced the mandatory version from 1.14 to 1.12 helped.  Apparently 1.12.2 is the latest version available on Unbuntu.  